### PR TITLE
fix: install lxml and BeautifulSoup4 instead of BeautifulSoup

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/bash
 
 sudo npm i svgexport -g
-sudo pip install Sphinx BeautifulSoup
+sudo pip install lxml Sphinx BeautifulSoup4
 
 git clone https://github.com/ethereum/solidity
 cd  solidity/docs


### PR DESCRIPTION
Hi, here you import bs4 https://github.com/oschvr/solidity-dash/blob/master/populate.py#L5,  which is the BeautifulSoup4's package name, the default BeautifulSoup version is 3.2.1, not matched. And bs4 also need `lxml` too, or it will arise error as below: 

```
docPage: types.html
Traceback (most recent call last):
  File "populate.py", line 25, in <module>
    soup = BeautifulSoup(page, 'lxml')
  File "/root/.virtualenvs/ans/local/lib/python2.7/site-packages/bs4/__init__.py", line 165, in __init__
    % ",".join(features))
bs4.FeatureNotFound: Couldn't find a tree builder with the features you requested: lxml. Do you need to install a parser library?
```